### PR TITLE
ogs-sha[12]-hmac: Ensure input (key, message) are not modified

### DIFF
--- a/src/crypt/ogs-sha1-hmac.c
+++ b/src/crypt/ogs-sha1-hmac.c
@@ -51,26 +51,24 @@
 
 #include "ogs-crypt.h"
 
-void ogs_hmac_sha1_init(ogs_hmac_sha1_ctx *ctx, uint8_t *key,
+void ogs_hmac_sha1_init(ogs_hmac_sha1_ctx *ctx, const uint8_t *key,
                       uint32_t key_size)
 {
     uint32_t fill;
     uint32_t num;
 
-    uint8_t *key_used;
     uint8_t key_temp[OGS_SHA1_DIGEST_SIZE];
     int i;
 
     if (key_size == OGS_SHA1_BLOCK_SIZE) {
-        key_used = key;
+        memcpy(key_temp, key, sizeof(key_temp));
         num = OGS_SHA1_BLOCK_SIZE;
     } else {
         if (key_size > OGS_SHA1_BLOCK_SIZE){
-            key_used = key_temp;
             num = OGS_SHA1_DIGEST_SIZE;
-            ogs_sha1(key, key_size, key_used);
+            ogs_sha1(key, key_size, key_temp);
         } else { /* key_size > SHA1_BLOCK_SIZE */
-            key_used = key;
+            memcpy(key_temp, key, sizeof(key_temp));
             num = key_size;
         }
         fill = OGS_SHA1_BLOCK_SIZE - num;
@@ -80,8 +78,8 @@ void ogs_hmac_sha1_init(ogs_hmac_sha1_ctx *ctx, uint8_t *key,
     }
 
     for (i = 0; i < num; i++) {
-        ctx->block_ipad[i] = key_used[i] ^ 0x36;
-        ctx->block_opad[i] = key_used[i] ^ 0x5c;
+        ctx->block_ipad[i] = key_temp[i] ^ 0x36;
+        ctx->block_opad[i] = key_temp[i] ^ 0x5c;
     }
 
     ogs_sha1_init(&ctx->ctx_inside);
@@ -106,7 +104,7 @@ void ogs_hmac_sha1_reinit(ogs_hmac_sha1_ctx *ctx)
            sizeof(ogs_sha1_ctx));
 }
 
-void ogs_hmac_sha1_update(ogs_hmac_sha1_ctx *ctx, uint8_t *message,
+void ogs_hmac_sha1_update(ogs_hmac_sha1_ctx *ctx, const uint8_t *message,
                         uint32_t message_len)
 {
     ogs_sha1_update(&ctx->ctx_inside, message, message_len);
@@ -124,8 +122,8 @@ void ogs_hmac_sha1_final(ogs_hmac_sha1_ctx *ctx, uint8_t *mac,
     memcpy(mac, mac_temp, mac_size);
 }
 
-void ogs_hmac_sha1(uint8_t *key, uint32_t key_size,
-          uint8_t *message, uint32_t message_len,
+void ogs_hmac_sha1(const uint8_t *key, uint32_t key_size,
+          const uint8_t *message, uint32_t message_len,
           uint8_t *mac, uint32_t mac_size)
 {
     ogs_hmac_sha1_ctx ctx;

--- a/src/crypt/ogs-sha1-hmac.h
+++ b/src/crypt/ogs-sha1-hmac.h
@@ -40,15 +40,15 @@ typedef struct {
     uint8_t block_opad[OGS_SHA1_BLOCK_SIZE];
 } ogs_hmac_sha1_ctx;
 
-void ogs_hmac_sha1_init(ogs_hmac_sha1_ctx *ctx, uint8_t *key,
+void ogs_hmac_sha1_init(ogs_hmac_sha1_ctx *ctx, const uint8_t *key,
                       uint32_t key_size);
 void ogs_hmac_sha1_reinit(ogs_hmac_sha1_ctx *ctx);
-void ogs_hmac_sha1_update(ogs_hmac_sha1_ctx *ctx, uint8_t *message,
+void ogs_hmac_sha1_update(ogs_hmac_sha1_ctx *ctx, const uint8_t *message,
                         uint32_t message_len);
 void ogs_hmac_sha1_final(ogs_hmac_sha1_ctx *ctx, uint8_t *mac,
                        uint32_t mac_size);
-void ogs_hmac_sha1(uint8_t *key, uint32_t key_size,
-                 uint8_t *message, uint32_t message_len,
+void ogs_hmac_sha1(const uint8_t *key, uint32_t key_size,
+                 const uint8_t *message, uint32_t message_len,
                  uint8_t *mac, uint32_t mac_size);
 
 #ifdef __cplusplus

--- a/src/crypt/ogs-sha2-hmac.c
+++ b/src/crypt/ogs-sha2-hmac.c
@@ -53,26 +53,24 @@
 
 /* HMAC-SHA-224 functions */
 
-void ogs_hmac_sha224_init(ogs_hmac_sha224_ctx *ctx, uint8_t *key,
+void ogs_hmac_sha224_init(ogs_hmac_sha224_ctx *ctx, const uint8_t *key,
                       uint32_t key_size)
 {
     uint32_t fill;
     uint32_t num;
 
-    uint8_t *key_used;
     uint8_t key_temp[OGS_SHA224_DIGEST_SIZE];
     int i;
 
     if (key_size == OGS_SHA224_BLOCK_SIZE) {
-        key_used = key;
+        memcpy(key_temp, key, sizeof(key_temp));
         num = OGS_SHA224_BLOCK_SIZE;
     } else {
         if (key_size > OGS_SHA224_BLOCK_SIZE){
-            key_used = key_temp;
             num = OGS_SHA224_DIGEST_SIZE;
-            ogs_sha224(key, key_size, key_used);
+            ogs_sha224(key, key_size, key_temp);
         } else { /* key_size > OGS_SHA224_BLOCK_SIZE */
-            key_used = key;
+            memcpy(key_temp, key, sizeof(key_temp));
             num = key_size;
         }
         fill = OGS_SHA224_BLOCK_SIZE - num;
@@ -82,8 +80,8 @@ void ogs_hmac_sha224_init(ogs_hmac_sha224_ctx *ctx, uint8_t *key,
     }
 
     for (i = 0; i < num; i++) {
-        ctx->block_ipad[i] = key_used[i] ^ 0x36;
-        ctx->block_opad[i] = key_used[i] ^ 0x5c;
+        ctx->block_ipad[i] = key_temp[i] ^ 0x36;
+        ctx->block_opad[i] = key_temp[i] ^ 0x5c;
     }
 
     ogs_sha224_init(&ctx->ctx_inside);
@@ -108,7 +106,7 @@ void ogs_hmac_sha224_reinit(ogs_hmac_sha224_ctx *ctx)
            sizeof(ogs_sha224_ctx));
 }
 
-void ogs_hmac_sha224_update(ogs_hmac_sha224_ctx *ctx, uint8_t *message,
+void ogs_hmac_sha224_update(ogs_hmac_sha224_ctx *ctx, const uint8_t *message,
                         uint32_t message_len)
 {
     ogs_sha224_update(&ctx->ctx_inside, message, message_len);
@@ -126,8 +124,8 @@ void ogs_hmac_sha224_final(ogs_hmac_sha224_ctx *ctx, uint8_t *mac,
     memcpy(mac, mac_temp, mac_size);
 }
 
-void ogs_hmac_sha224(uint8_t *key, uint32_t key_size,
-          uint8_t *message, uint32_t message_len,
+void ogs_hmac_sha224(const uint8_t *key, uint32_t key_size,
+          const uint8_t *message, uint32_t message_len,
           uint8_t *mac, uint32_t mac_size)
 {
     ogs_hmac_sha224_ctx ctx;
@@ -139,26 +137,24 @@ void ogs_hmac_sha224(uint8_t *key, uint32_t key_size,
 
 /* HMAC-SHA-256 functions */
 
-void ogs_hmac_sha256_init(ogs_hmac_sha256_ctx *ctx, uint8_t *key,
+void ogs_hmac_sha256_init(ogs_hmac_sha256_ctx *ctx, const uint8_t *key,
                       uint32_t key_size)
 {
     uint32_t fill;
     uint32_t num;
 
-    uint8_t *key_used;
     uint8_t key_temp[OGS_SHA256_DIGEST_SIZE];
     int i;
 
     if (key_size == OGS_SHA256_BLOCK_SIZE) {
-        key_used = key;
+        memcpy(key_temp, key, sizeof(key_temp));
         num = OGS_SHA256_BLOCK_SIZE;
     } else {
         if (key_size > OGS_SHA256_BLOCK_SIZE){
-            key_used = key_temp;
             num = OGS_SHA256_DIGEST_SIZE;
-            ogs_sha256(key, key_size, key_used);
+            ogs_sha256(key, key_size, key_temp);
         } else { /* key_size > OGS_SHA256_BLOCK_SIZE */
-            key_used = key;
+            memcpy(key_temp, key, sizeof(key_temp));
             num = key_size;
         }
         fill = OGS_SHA256_BLOCK_SIZE - num;
@@ -168,8 +164,8 @@ void ogs_hmac_sha256_init(ogs_hmac_sha256_ctx *ctx, uint8_t *key,
     }
 
     for (i = 0; i < num; i++) {
-        ctx->block_ipad[i] = key_used[i] ^ 0x36;
-        ctx->block_opad[i] = key_used[i] ^ 0x5c;
+        ctx->block_ipad[i] = key_temp[i] ^ 0x36;
+        ctx->block_opad[i] = key_temp[i] ^ 0x5c;
     }
 
     ogs_sha256_init(&ctx->ctx_inside);
@@ -194,7 +190,7 @@ void ogs_hmac_sha256_reinit(ogs_hmac_sha256_ctx *ctx)
            sizeof(ogs_sha256_ctx));
 }
 
-void ogs_hmac_sha256_update(ogs_hmac_sha256_ctx *ctx, uint8_t *message,
+void ogs_hmac_sha256_update(ogs_hmac_sha256_ctx *ctx, const uint8_t *message,
                         uint32_t message_len)
 {
     ogs_sha256_update(&ctx->ctx_inside, message, message_len);
@@ -212,8 +208,8 @@ void ogs_hmac_sha256_final(ogs_hmac_sha256_ctx *ctx, uint8_t *mac,
     memcpy(mac, mac_temp, mac_size);
 }
 
-void ogs_hmac_sha256(uint8_t *key, uint32_t key_size,
-          uint8_t *message, uint32_t message_len,
+void ogs_hmac_sha256(const uint8_t *key, uint32_t key_size,
+          const uint8_t *message, uint32_t message_len,
           uint8_t *mac, uint32_t mac_size)
 {
     ogs_hmac_sha256_ctx ctx;
@@ -225,26 +221,24 @@ void ogs_hmac_sha256(uint8_t *key, uint32_t key_size,
 
 /* HMAC-SHA-384 functions */
 
-void ogs_hmac_sha384_init(ogs_hmac_sha384_ctx *ctx, uint8_t *key,
+void ogs_hmac_sha384_init(ogs_hmac_sha384_ctx *ctx, const uint8_t *key,
                       uint32_t key_size)
 {
     uint32_t fill;
     uint32_t num;
 
-    uint8_t *key_used;
     uint8_t key_temp[OGS_SHA384_DIGEST_SIZE];
     int i;
 
     if (key_size == OGS_SHA384_BLOCK_SIZE) {
-        key_used = key;
+        memcpy(key_temp, key, sizeof(key_temp));
         num = OGS_SHA384_BLOCK_SIZE;
     } else {
         if (key_size > OGS_SHA384_BLOCK_SIZE){
-            key_used = key_temp;
             num = OGS_SHA384_DIGEST_SIZE;
-            ogs_sha384(key, key_size, key_used);
+            ogs_sha384(key, key_size, key_temp);
         } else { /* key_size > OGS_SHA384_BLOCK_SIZE */
-            key_used = key;
+            memcpy(key_temp, key, sizeof(key_temp));
             num = key_size;
         }
         fill = OGS_SHA384_BLOCK_SIZE - num;
@@ -254,8 +248,8 @@ void ogs_hmac_sha384_init(ogs_hmac_sha384_ctx *ctx, uint8_t *key,
     }
 
     for (i = 0; i < num; i++) {
-        ctx->block_ipad[i] = key_used[i] ^ 0x36;
-        ctx->block_opad[i] = key_used[i] ^ 0x5c;
+        ctx->block_ipad[i] = key_temp[i] ^ 0x36;
+        ctx->block_opad[i] = key_temp[i] ^ 0x5c;
     }
 
     ogs_sha384_init(&ctx->ctx_inside);
@@ -280,7 +274,7 @@ void ogs_hmac_sha384_reinit(ogs_hmac_sha384_ctx *ctx)
            sizeof(ogs_sha384_ctx));
 }
 
-void ogs_hmac_sha384_update(ogs_hmac_sha384_ctx *ctx, uint8_t *message,
+void ogs_hmac_sha384_update(ogs_hmac_sha384_ctx *ctx, const uint8_t *message,
                         uint32_t message_len)
 {
     ogs_sha384_update(&ctx->ctx_inside, message, message_len);
@@ -298,8 +292,8 @@ void ogs_hmac_sha384_final(ogs_hmac_sha384_ctx *ctx, uint8_t *mac,
     memcpy(mac, mac_temp, mac_size);
 }
 
-void ogs_hmac_sha384(uint8_t *key, uint32_t key_size,
-          uint8_t *message, uint32_t message_len,
+void ogs_hmac_sha384(const uint8_t *key, uint32_t key_size,
+          const uint8_t *message, uint32_t message_len,
           uint8_t *mac, uint32_t mac_size)
 {
     ogs_hmac_sha384_ctx ctx;
@@ -311,26 +305,24 @@ void ogs_hmac_sha384(uint8_t *key, uint32_t key_size,
 
 /* HMAC-SHA-512 functions */
 
-void ogs_hmac_sha512_init(ogs_hmac_sha512_ctx *ctx, uint8_t *key,
+void ogs_hmac_sha512_init(ogs_hmac_sha512_ctx *ctx, const uint8_t *key,
                       uint32_t key_size)
 {
     uint32_t fill;
     uint32_t num;
 
-    uint8_t *key_used;
     uint8_t key_temp[OGS_SHA512_DIGEST_SIZE];
     int i;
 
     if (key_size == OGS_SHA512_BLOCK_SIZE) {
-        key_used = key;
+        memcpy(key_temp, key, sizeof(key_temp));
         num = OGS_SHA512_BLOCK_SIZE;
     } else {
         if (key_size > OGS_SHA512_BLOCK_SIZE){
-            key_used = key_temp;
             num = OGS_SHA512_DIGEST_SIZE;
-            ogs_sha512(key, key_size, key_used);
+            ogs_sha512(key, key_size, key_temp);
         } else { /* key_size > OGS_SHA512_BLOCK_SIZE */
-            key_used = key;
+            memcpy(key_temp, key, sizeof(key_temp));
             num = key_size;
         }
         fill = OGS_SHA512_BLOCK_SIZE - num;
@@ -340,8 +332,8 @@ void ogs_hmac_sha512_init(ogs_hmac_sha512_ctx *ctx, uint8_t *key,
     }
 
     for (i = 0; i < num; i++) {
-        ctx->block_ipad[i] = key_used[i] ^ 0x36;
-        ctx->block_opad[i] = key_used[i] ^ 0x5c;
+        ctx->block_ipad[i] = key_temp[i] ^ 0x36;
+        ctx->block_opad[i] = key_temp[i] ^ 0x5c;
     }
 
     ogs_sha512_init(&ctx->ctx_inside);
@@ -366,7 +358,7 @@ void ogs_hmac_sha512_reinit(ogs_hmac_sha512_ctx *ctx)
            sizeof(ogs_sha512_ctx));
 }
 
-void ogs_hmac_sha512_update(ogs_hmac_sha512_ctx *ctx, uint8_t *message,
+void ogs_hmac_sha512_update(ogs_hmac_sha512_ctx *ctx, const uint8_t *message,
                         uint32_t message_len)
 {
     ogs_sha512_update(&ctx->ctx_inside, message, message_len);
@@ -384,8 +376,8 @@ void ogs_hmac_sha512_final(ogs_hmac_sha512_ctx *ctx, uint8_t *mac,
     memcpy(mac, mac_temp, mac_size);
 }
 
-void ogs_hmac_sha512(uint8_t *key, uint32_t key_size,
-          uint8_t *message, uint32_t message_len,
+void ogs_hmac_sha512(const uint8_t *key, uint32_t key_size,
+          const uint8_t *message, uint32_t message_len,
           uint8_t *mac, uint32_t mac_size)
 {
     ogs_hmac_sha512_ctx ctx;

--- a/src/crypt/ogs-sha2-hmac.h
+++ b/src/crypt/ogs-sha2-hmac.h
@@ -76,48 +76,48 @@ typedef struct {
     uint8_t block_opad[OGS_SHA512_BLOCK_SIZE];
 } ogs_hmac_sha512_ctx;
 
-void ogs_hmac_sha224_init(ogs_hmac_sha224_ctx *ctx, uint8_t *key,
+void ogs_hmac_sha224_init(ogs_hmac_sha224_ctx *ctx, const uint8_t *key,
                       uint32_t key_size);
 void ogs_hmac_sha224_reinit(ogs_hmac_sha224_ctx *ctx);
-void ogs_hmac_sha224_update(ogs_hmac_sha224_ctx *ctx, uint8_t *message,
+void ogs_hmac_sha224_update(ogs_hmac_sha224_ctx *ctx, const uint8_t *message,
                         uint32_t message_len);
 void ogs_hmac_sha224_final(ogs_hmac_sha224_ctx *ctx, uint8_t *mac,
                        uint32_t mac_size);
-void ogs_hmac_sha224(uint8_t *key, uint32_t key_size,
-                 uint8_t *message, uint32_t message_len,
+void ogs_hmac_sha224(const uint8_t *key, uint32_t key_size,
+                 const uint8_t *message, uint32_t message_len,
                  uint8_t *mac, uint32_t mac_size);
 
-void ogs_hmac_sha256_init(ogs_hmac_sha256_ctx *ctx, uint8_t *key,
+void ogs_hmac_sha256_init(ogs_hmac_sha256_ctx *ctx, const uint8_t *key,
                       uint32_t key_size);
 void ogs_hmac_sha256_reinit(ogs_hmac_sha256_ctx *ctx);
-void ogs_hmac_sha256_update(ogs_hmac_sha256_ctx *ctx, uint8_t *message,
+void ogs_hmac_sha256_update(ogs_hmac_sha256_ctx *ctx, const uint8_t *message,
                         uint32_t message_len);
 void ogs_hmac_sha256_final(ogs_hmac_sha256_ctx *ctx, uint8_t *mac,
                        uint32_t mac_size);
-void ogs_hmac_sha256(uint8_t *key, uint32_t key_size,
-                 uint8_t *message, uint32_t message_len,
+void ogs_hmac_sha256(const uint8_t *key, uint32_t key_size,
+                 const uint8_t *message, uint32_t message_len,
                  uint8_t *mac, uint32_t mac_size);
 
-void ogs_hmac_sha384_init(ogs_hmac_sha384_ctx *ctx, uint8_t *key,
+void ogs_hmac_sha384_init(ogs_hmac_sha384_ctx *ctx, const uint8_t *key,
                       uint32_t key_size);
 void ogs_hmac_sha384_reinit(ogs_hmac_sha384_ctx *ctx);
-void ogs_hmac_sha384_update(ogs_hmac_sha384_ctx *ctx, uint8_t *message,
+void ogs_hmac_sha384_update(ogs_hmac_sha384_ctx *ctx, const uint8_t *message,
                         uint32_t message_len);
 void ogs_hmac_sha384_final(ogs_hmac_sha384_ctx *ctx, uint8_t *mac,
                        uint32_t mac_size);
-void ogs_hmac_sha384(uint8_t *key, uint32_t key_size,
-                 uint8_t *message, uint32_t message_len,
+void ogs_hmac_sha384(const uint8_t *key, uint32_t key_size,
+                 const uint8_t *message, uint32_t message_len,
                  uint8_t *mac, uint32_t mac_size);
 
-void ogs_hmac_sha512_init(ogs_hmac_sha512_ctx *ctx, uint8_t *key,
+void ogs_hmac_sha512_init(ogs_hmac_sha512_ctx *ctx, const uint8_t *key,
                       uint32_t key_size);
 void ogs_hmac_sha512_reinit(ogs_hmac_sha512_ctx *ctx);
-void ogs_hmac_sha512_update(ogs_hmac_sha512_ctx *ctx, uint8_t *message,
+void ogs_hmac_sha512_update(ogs_hmac_sha512_ctx *ctx, const uint8_t *message,
                         uint32_t message_len);
 void ogs_hmac_sha512_final(ogs_hmac_sha512_ctx *ctx, uint8_t *mac,
                        uint32_t mac_size);
-void ogs_hmac_sha512(uint8_t *key, uint32_t key_size,
-                 uint8_t *message, uint32_t message_len,
+void ogs_hmac_sha512(const uint8_t *key, uint32_t key_size,
+                 const uint8_t *message, uint32_t message_len,
                  uint8_t *mac, uint32_t mac_size);
 
 #ifdef __cplusplus


### PR DESCRIPTION
When calling a HMAC API, the input is the key and the message,
and the output is the generate HMAC.  Functions should not modify
the input data, as this can lead to all kinds of strange side-effects.

Let's ensure input data are not modified and subsequently mark input
arguments with 'const' qualifier.