### PR TITLE
Fix installation of all header files

### DIFF
--- a/src/core/Makefile.am
+++ b/src/core/Makefile.am
@@ -39,7 +39,7 @@ coreinclude_HEADERS = \
 	ogs-compat.h ogs-macros.h \
 	ogs-pool.h ogs-list.h \
 	ogs-abort.h ogs-errno.h \
-	ogs-strings.h ogs-time.h ogs-conv.h
+	ogs-strings.h ogs-time.h ogs-conv.h \
 	ogs-log.h ogs-pkbuf.h ogs-memory.h ogs-rbtree.h ogs-timer.h \
 	ogs-rand.h ogs-thread.h ogs-signal.h ogs-process.h \
 	ogs-sockaddr.h ogs-socket.h ogs-sockpair.h ogs-socknode.h \


### PR DESCRIPTION
In 45cf105 one backslash was removed probably by mistake and as a result compilation of `nextepc` fails with

```
  CC       types.lo
In file included from types.h:23,
                 from types.c:20:
/usr/local/include/ogslib-1.0/ogs-core.h:34:10: fatal error: core/ogs-log.h: No such file or directory
 #include "core/ogs-log.h"
          ^~~~~~~~~~~~~~~~
compilation terminated.
```